### PR TITLE
Fix prompt matching and improve debugability

### DIFF
--- a/entrance/__main__.py
+++ b/entrance/__main__.py
@@ -4,7 +4,9 @@
 
 import argparse, logging, logging.config, sys
 import sanic, sanic.response, yaml
+
 from . import WebsocketHandler
+from ._util import logger
 
 log = logging.getLogger(__name__)
 location = getattr(sys, '_MEIPASS', '.') + '/' # where pre-canned files live
@@ -82,6 +84,7 @@ def main(*args, task=None):
 
     # Go
     logging.config.dictConfig(logging_config)
+    logging.setLogRecordFactory(logger.FormattedLogRecord)
     start(main_config, task)
     log.info('Closing down gracefully')
 

--- a/entrance/connection/base.py
+++ b/entrance/connection/base.py
@@ -5,6 +5,9 @@
 import asyncio
 from enum import IntEnum, unique
 
+from .._util import events
+
+
 @unique
 class ConState(IntEnum):
     # Order is important: overall connection state is the max of the
@@ -94,4 +97,4 @@ class Connection():
                 if self.finalizer is not None:
                     await self.finalizer()
                 await self._set_state(ConState.CONNECTED)
-            asyncio.ensure_future(finalize())
+            events.create_checked_task(finalize())

--- a/entrance/connection/cli.py
+++ b/entrance/connection/cli.py
@@ -32,7 +32,7 @@ class ThreadedCLIConnection(ThreadedConnection):
         return await self._request('settimeout', override, timeout)
 
     # Regexps for _expect_prompt below
-    _prompt = re.compile(r'(.*)RP/0/0/CPU0:[^\r\n]*?#', re.DOTALL)
+    _prompt = re.compile(r'(.*)RP/0/(RP)?0/CPU0:[^\r\n]*?#', re.DOTALL)
     _interesting = re.compile(r'[^\n]*\n[^\n]* UTC\r\n(.*)', re.DOTALL)
 
     async def expect_prompt(self, strip_top=False, override=False):

--- a/entrance/connection/threaded.py
+++ b/entrance/connection/threaded.py
@@ -5,7 +5,9 @@
 
 import logging, re, threading, traceback
 import asyncio, janus
-from entrance.connection.base import Connection, ConState
+
+from .base import Connection, ConState
+from .._util import events
 
 log = logging.getLogger(__name__)
 
@@ -37,7 +39,7 @@ class ThreadedConnection(Connection):
                                        target=self._thread_main,
                                        kwargs=kwargs)
         self.thread.start()
-        self.event_loop_task = asyncio.ensure_future(self._event_loop())
+        self.event_loop_task = events.create_checked_task(self._event_loop())
 
     async def disconnect(self):
         """

--- a/entrance/feature/tgt_base.py
+++ b/entrance/feature/tgt_base.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2018 Ensoft Ltd
 
 import asyncio, logging, time
-from entrance.connection import connection_factory_by_name, ConState, Connection
+
+from ..connection import connection_factory_by_name, ConState, Connection
+from .._util import events
 from .dyn_base import DynamicFeature
 
 log = logging.getLogger(__name__)
@@ -87,7 +89,7 @@ class TargetFeature(DynamicFeature):
         # Connections can be removed mid-iteration if they disconnect promptly
         safe_iter = list(self.children)
         for child in safe_iter:
-            asyncio.ensure_future(child.disconnect())
+            events.create_checked_task(child.disconnect())
 
     def add_connection(self, connection, from_scratch=False):
         """

--- a/entrance/feature/tgt_group.py
+++ b/entrance/feature/tgt_group.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2018 Ensoft Ltd
 
 import asyncio, time
+
+from .._util import events
 from .tgt_base import TargetFeature
 
 class TargetGroupFeature(TargetFeature):
@@ -36,7 +38,7 @@ class TargetGroupFeature(TargetFeature):
         Initiate all the connections to this target
         """
         for child in self.children:
-            asyncio.ensure_future(child.connect(conn_factory))
+            events.create_checked_task(child.connect(conn_factory))
 
     def add_feature(self, feature):
         """
@@ -47,7 +49,7 @@ class TargetGroupFeature(TargetFeature):
         if self.connect_requested:
             # A connect request has already been made. So the late-arrival
             # feature should try to connect now too.
-            asyncio.ensure_future(feature.connect(self.conn_factory))
+            events.create_checked_task(feature.connect(self.conn_factory))
 
     def remove_feature(self, feature):
         """

--- a/entrance/feature/tgt_syslog.py
+++ b/entrance/feature/tgt_syslog.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2018 Ensoft Ltd
 
 import asyncio, re, time
+
+from .._util import events
 from .tgt_base import TargetFeature
 
 class SyslogFeature(TargetFeature):
@@ -52,7 +54,7 @@ class SyslogFeature(TargetFeature):
 
         # We need to return at this point, so the connection transitions
         # from FINALIZING to CONNECTED, so tee up our mini event loop for later
-        asyncio.ensure_future(self._event_loop(regexp, nfn))
+        events.create_checked_task(self._event_loop(regexp, nfn))
 
     async def _event_loop(self, regexp, nfn):
         """

--- a/entrance/ws_handler.py
+++ b/entrance/ws_handler.py
@@ -5,8 +5,10 @@
 from collections import defaultdict
 import asyncio, logging, re, traceback
 import ujson
-from entrance.connection import ConState
-from entrance.feature import *
+
+from .connection import ConState
+from .feature import *
+from ._util import events
 
 log = logging.getLogger(__name__)
 
@@ -90,7 +92,7 @@ class WebsocketHandler():
             try:
                 key = _mktuple(req_type, endpoint, target)
                 feature = self.request_map_optional[key]
-                asyncio.ensure_future(feature.handle(request))
+                events.create_checked_task(feature.handle(request))
             except KeyError:
                 log.warning('Un-handleable request {}'.format(request))
                 log.debug('key = {}, request_map_optional = {}'.format(


### PR DESCRIPTION
Certain platforms have "RP" in their node IDs. Prompt matching needs to be updated to (optionally) account for this.

Along the way made a couple of debugability improvements:

1. Crash if an unhandled exception propagates from a task (controversial? I claim this always indicates a bug, so isn't unreasonable: discuss :))

2. Add a bit of logging around connection state changes. In particular add a custom LogRecord to allow (but not require) {}-style formatting in logs.