### PR TITLE
Improve the logging when websocket connections are closed

### DIFF
--- a/python/entrance/ws_handler.py
+++ b/python/entrance/ws_handler.py
@@ -53,13 +53,13 @@ class WebsocketHandler():
             try:
                 req = await self.ws.recv()
                 got_req = True
-            except asyncio.CancelledError:
+            except (asyncio.CancelledError, ConnectionClosed):
                 log.info('Websocket closed')
                 for feature in self.features:
                     feature.close()
                 break
             except Exception as e:
-                log.error('Websocket recv exception', e)
+                log.error('Websocket recv exception: %s', e)
             try:
                 if got_req:
                     await self._handle_req(req)


### PR DESCRIPTION
Previously when refreshing a tab the logs were being spammed with sometimes hundreds of "ERROR: [entrance.ws_handler] Websocket recv exception" messages.
After this change there is a single "INFO: [entrance.ws_handler] Websocket closed" message, and any errors that are reported under the "Websocket recv exception" will be included in the log message (as it seems was intended).