### PR TITLE
Use a static port for the hot-module-replacement websocket.

### DIFF
--- a/samples/1_notes/elm/package.json
+++ b/samples/1_notes/elm/package.json
@@ -16,7 +16,7 @@
     "sass": "^1.18.0"
   },
   "scripts": {
-    "dev": "parcel src/index.html",
+    "dev": "parcel src/index.html --hmr-port 41234",
     "build": "parcel build src/index.html --no-content-hash --public-url ./"
   }
 }

--- a/samples/2_shell/elm/package.json
+++ b/samples/2_shell/elm/package.json
@@ -17,7 +17,7 @@
     "sass": "^1.18.0"
   },
   "scripts": {
-    "dev": "parcel src/index.html",
+    "dev": "parcel src/index.html --hmr-port 41234",
     "build": "parcel build src/index.html --no-content-hash --public-url ./"
   }
 }

--- a/samples/3_browser/elm/package.json
+++ b/samples/3_browser/elm/package.json
@@ -17,7 +17,7 @@
     "sass": "^1.18.0"
   },
   "scripts": {
-    "dev": "parcel src/index.html",
+    "dev": "parcel src/index.html --hmr-port 41234",
     "build": "parcel build src/index.html --no-content-hash --public-url ./"
   }
 }

--- a/samples/4_router_simple/elm/package.json
+++ b/samples/4_router_simple/elm/package.json
@@ -18,7 +18,7 @@
     "sass": "^1.18.0"
   },
   "scripts": {
-    "dev": "parcel src/index.html",
+    "dev": "parcel src/index.html --hmr-port 41234",
     "build": "parcel build src/index.html --no-content-hash --public-url ./"
   },
   "assetsPath": "images"


### PR DESCRIPTION
That way it can be fowarded from the host when running EnTrance in a VM.