### PR TITLE
Add main() API to entrance package

### DIFF
--- a/python/entrance/__init__.py
+++ b/python/entrance/__init__.py
@@ -1,3 +1,12 @@
+import runpy
+
 from entrance.connection import *
 from entrance.feature import *
 from entrance.ws_handler import *
+
+
+def main():
+    """
+    Run the entrance module (via __main__.py) in the current Python process.
+    """
+    runpy.run_module("entrance", run_name="__main__")

--- a/samples/2_shell/svr/run.py
+++ b/samples/2_shell/svr/run.py
@@ -8,8 +8,10 @@
 # Since this is a configured feature, you need your config.yaml file
 # to include it, otherwise your feature won't be started.
 
-import asyncio, logging, sys
+import asyncio, logging
 from asyncio.subprocess import PIPE
+
+import entrance
 from entrance.feature.cfg_base import ConfiguredFeature
 
 # For production use, this wouldn't require any additional logging.
@@ -52,6 +54,4 @@ class InsecureShellFeature(ConfiguredFeature):
 
 
 # Start up
-from entrance.__main__ import main
-
-main(*sys.argv[1:])
+entrance.main()

--- a/samples/3_browser/svr/run.py
+++ b/samples/3_browser/svr/run.py
@@ -8,8 +8,10 @@
 # Since this is a configured feature, you need your config.yaml file
 # to include it, otherwise your feature won't be started.
 
-import logging, os, sys
+import logging, os
 from pathlib import Path
+
+import entrance
 from entrance.feature.cfg_base import ConfiguredFeature
 
 # For production use, this wouldn't require any additional logging.
@@ -60,6 +62,4 @@ class DirectoryFeature(ConfiguredFeature):
 
 
 # Start up
-from entrance.__main__ import main
-
-main(*sys.argv[1:])
+entrance.main()

--- a/samples/4_router_simple/svr/run
+++ b/samples/4_router_simple/svr/run
@@ -5,14 +5,14 @@
 import os, shutil, sys
 from multiprocessing import Process, freeze_support
 
+import entrance
 
-def run(*args):
+
+def run():
     """
     Run one instance of the server in a separate process
     """
-    from entrance.__main__ import main
-
-    main(*args)
+    entrance.main()
 
 
 if __name__ == "__main__":
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     # Spawn a server, and spawn a new one if requested by the client
     # (indicated by exit code 42)
     while True:
-        p = Process(target=run, args=sys.argv[1:])
+        p = Process(target=run)
         p.start()
         try:
             p.join()


### PR DESCRIPTION
… and use this rather than importing `__main__` in examples.

Bear in mind this uses `sys.argv`, and isn't customisable (it's just running `__main__.py` after all). I think this is fine, since this is intended as a quick and simple option (and modifying `sys.argv` is still an option).

See discussion on #6.