### PR TITLE
Stop using sys.exit() when something unexpected happens in EnTrance

### DIFF
--- a/python/entrance/__init__.py
+++ b/python/entrance/__init__.py
@@ -1,6 +1,7 @@
 import runpy
 
 from entrance.connection import *
+from entrance.exceptions import *
 from entrance.feature import *
 from entrance.ws_handler import *
 

--- a/python/entrance/exceptions.py
+++ b/python/entrance/exceptions.py
@@ -1,0 +1,9 @@
+# EnTrance exceptions
+#
+# Copyright (c) 2021 Ensoft Ltd
+
+__all__ = ("EntranceError",)
+
+
+class EntranceError(Exception):
+    """Generic EnTrance exception."""

--- a/python/entrance/feature/base.py
+++ b/python/entrance/feature/base.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2018 Ensoft Ltd
 
 import logging, sys
+from ..exceptions import EntranceError
 
 log = logging.getLogger(__name__)
 
@@ -116,13 +117,10 @@ class Feature:
         Check that we're conforming to our own schema declaration
         """
         if nfn_type not in self.notifications:
-            log.critical(
-                "\n!!\n!!\n!! Feature %s trying to send disallowed "
-                "notification %s\n!!\n!!",
-                self.name,
-                nfn_type,
-            )
-            sys.exit(1)
+            msg = "Feature {} trying to send disallowed notification {}".format(
+                self.name, nfn_type)
+            log.critical("\n!!\n!!\n!! %s\n!!\n!!", msg)
+            raise EntranceError(msg)
 
     async def _notify(self, **nfn):
         """

--- a/python/entrance/feature/base.py
+++ b/python/entrance/feature/base.py
@@ -2,7 +2,8 @@
 #
 # Copyright (c) 2018 Ensoft Ltd
 
-import logging, sys
+import logging
+
 from ..exceptions import EntranceError
 
 log = logging.getLogger(__name__)

--- a/python/entrance/feature/cfg_base.py
+++ b/python/entrance/feature/cfg_base.py
@@ -2,7 +2,8 @@
 #
 # Copyright (c) 2018 Ensoft Ltd
 
-import logging, sys
+import logging
+
 from .base import Feature
 from ..exceptions import EntranceError
 

--- a/python/entrance/feature/cfg_base.py
+++ b/python/entrance/feature/cfg_base.py
@@ -4,6 +4,7 @@
 
 import logging, sys
 from .base import Feature
+from ..exceptions import EntranceError
 
 log = logging.getLogger(__name__)
 
@@ -25,14 +26,15 @@ class ConfiguredFeature(Feature):
             if key in self.config:
                 self.config[key] = val
             else:
+                msg_parts = [
+                    'Invalid config item "{}" for feature {}'.format(key, self.name),
+                    'Possible items are: {}'.format(sorted(self.config.keys())),
+                ]
                 log.critical(
-                    '\n!!\n!!\n!! Invalid config item "%s" for feature %s\n'
-                    "!! Possible items are: %s\n!!\n!!\n!!",
-                    key,
-                    self.name,
-                    sorted(self.config.keys()),
+                    "\n!!\n!!\n!! %s\n!!\n!!\n!!",
+                    "\n!! ".join(msg_parts)
                 )
-                sys.exit(1)
+                raise EntranceError(". ".join(msg_parts))
 
     @classmethod
     def all(cls):


### PR DESCRIPTION
Fixes #13 

It's the change in `Feature._check_nfn_type()` that seems important, as it's possible to hit when a user has a cached out-of-date version of the Elm code, and is recoverable.

The change in `ConfiguredFeature.__init__()` is less obviously the right choice because it seems the websocket keeps trying (and failing) to connect until the browser tab is closed. However, this can still be considered recoverable (configured features won't always be loaded - it could be a rarely used feature in theory).

Using `samples/2_shell/` with modified 'requests', previously this crashed the server, now just gives:
```
INFO: [entrance.feature.base] Received an unparseable JSON request
CRITICAL: [entrance.feature.base]
!!
!!
!! Feature insecure_shell trying to send disallowed notification error
!!
!!
ERROR: [entrance.ws_handler] Exception during _handle_req: Feature insecure_shell trying to send disallowed notification error (see debug.log for details)
```

Passing invalid config to a `ConfiguredFeature` and trying to connect a websocket gives repeated output of:
```
INFO: [__main__] New websocket client
CRITICAL: [entrance.feature.cfg_base]
!!
!!
!! Invalid config item "foo" for feature insecure_shell
!! Possible items are: []
!!
!!
!!
[2021-02-03 22:25:50 +0000] [6196] [ERROR] Exception occurred while handling uri: 'ws://localhost:8000/ws'
Traceback (most recent call last):
  File "/mnt/c/Users/legaul/entrance/venv-tmp/lib/python3.6/site-packages/sanic/app.py", line 914, in handle_request
    response = await response
  File "/mnt/c/Users/legaul/entrance/venv-tmp/lib/python3.6/site-packages/sanic/app.py", line 1383, in _websocket_handler
    await fut
  File "/mnt/c/Users/legaul/entrance/python/entrance/__main__.py", line 33, in handle_ws
    ws_handler = WebsocketHandler(ws, config["features"])
  File "/mnt/c/Users/legaul/entrance/python/entrance/ws_handler.py", line 46, in __init__
    self.add_feature(feature_cls(self, feature_config[name]))
  File "run.py", line 37, in __init__
    super().__init__(ws_handler, {"foo": 1})
  File "/mnt/c/Users/legaul/entrance/python/entrance/feature/cfg_base.py", line 38, in __init__
    raise EntranceError(". ".join(msg_parts))
entrance.exceptions.EntranceError: Invalid config item "foo" for feature insecure_shell. Possible items are: []
```