### PR TITLE
Timeout for clients

### DIFF
--- a/python/entrance/ws_handler.py
+++ b/python/entrance/ws_handler.py
@@ -49,7 +49,10 @@ class WebsocketHandler:
 
     async def handle_incoming_requests(self, timeout=None):
         """
-        Mini-event loop that listens for incoming requests and handles them
+        Mini-event loop that listens for incoming requests and handles them.
+
+        A timeout in seconds can optionally be supplied. If this timeout is
+        elapsed while waiting for a request, all features are closed.
         """
         while True:
             got_req = False

--- a/python/entrance/ws_handler.py
+++ b/python/entrance/ws_handler.py
@@ -49,14 +49,14 @@ class WebsocketHandler:
 
     async def handle_incoming_requests(self):
         """
-        Mini-event loop that listens for incoming requests and handles them.
+        Mini-event loop that listens for incoming requests and handles them
         """
         while True:
             got_req = False
             try:
-                # If client is inactive for 15 minutes, send a ping to verify
+                # If client is inactive for 10 minutes, send a ping to verify
                 # connectivity
-                req = await asyncio.wait_for(self.ws.recv(), timeout=15*60)
+                req = await asyncio.wait_for(self.ws.recv(), timeout=10*60)
                 got_req = True
             except asyncio.TimeoutError:
                 try:

--- a/python/setup.py
+++ b/python/setup.py
@@ -35,7 +35,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="entrance",
-    version="1.1.15",
+    version="1.1.16",
     author="Ensoft Ltd",
     description="Server framework for web apps",
     url="https://github.com/ensoft/entrance",

--- a/python/setup.py
+++ b/python/setup.py
@@ -35,7 +35,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="entrance",
-    version="1.1.16",
+    version="1.1.17",
     author="Ensoft Ltd",
     description="Server framework for web apps",
     url="https://github.com/ensoft/entrance",


### PR DESCRIPTION
If a client is inactive for 10 minutes, send a ping, and if you get no response close that websocket.
Required to close dangling/lost client connections.
Manually tested.