### PR TITLE
Update all examples to work with node 26 (latest LTS)

### DIFF
--- a/samples/1_notes/elm/package.json
+++ b/samples/1_notes/elm/package.json
@@ -4,15 +4,17 @@
   "description": "Simple EnTrance example",
   "license": "MIT",
   "dependencies": {
-    "entrance-ws": "^1.1.1",
-    "parcel-bundler": "^1.12.3"
+    "entrance-ws": "^1.1.1"
   },
   "devDependencies": {
+    "@parcel/transformer-elm": "2.16.4",
+    "@parcel/transformer-sass": "2.16.4",
     "cssnano": "^4.1.10",
     "elm": "^0.19.1-1",
     "elm-analyse": "^0.16.4",
     "elm-hot": "^1.0.1",
     "node-elm-compiler": "^5.0.3",
+    "parcel": "^2.16.4",
     "sass": "^1.18.0"
   },
   "scripts": {

--- a/samples/1_notes/elm/src/index.html
+++ b/samples/1_notes/elm/src/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="static/bootstrap.min.css">
     <link rel="stylesheet" href="style.scss">
     <link rel="shortcut icon" href="static/favicon.ico">
-    <script defer src="main.js"></script>
+    <script defer type="module" src="main.js"></script>
     <title>EnTrance notes demo</title>
   </head>
   <body>

--- a/samples/2_shell/elm/package.json
+++ b/samples/2_shell/elm/package.json
@@ -5,15 +5,17 @@
   "license": "MIT",
   "dependencies": {
     "entrance-ws": "^1.1.1",
-    "global": "^4.3.2",
-    "parcel-bundler": "^1.12.3"
+    "global": "^4.3.2"
   },
   "devDependencies": {
+    "@parcel/transformer-elm": "2.16.4",
+    "@parcel/transformer-sass": "2.16.4",
     "cssnano": "^4.1.10",
     "elm": "^0.19.1-1",
     "elm-analyse": "^0.16.4",
     "elm-hot": "^1.0.1",
     "node-elm-compiler": "^5.0.3",
+    "parcel": "^2.16.4",
     "sass": "^1.18.0"
   },
   "scripts": {

--- a/samples/2_shell/elm/src/index.html
+++ b/samples/2_shell/elm/src/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="static/bootstrap.min.css">
     <link rel="stylesheet" href="style.scss">
     <link rel="shortcut icon" href="static/favicon.ico">
-    <script defer src="main.js"></script>
+    <script defer type="module" src="main.js"></script>
     <title>EnTrance notes demo</title>
   </head>
   <body>

--- a/samples/3_browser/elm/package.json
+++ b/samples/3_browser/elm/package.json
@@ -5,15 +5,17 @@
   "license": "MIT",
   "dependencies": {
     "entrance-ws": "^1.1.1",
-    "global": "^4.3.2",
-    "parcel-bundler": "^1.12.3"
+    "global": "^4.3.2"
   },
   "devDependencies": {
+    "@parcel/transformer-elm": "2.16.4",
+    "@parcel/transformer-sass": "2.16.4",
     "cssnano": "^4.1.10",
     "elm": "^0.19.1-1",
     "elm-analyse": "^0.16.4",
     "elm-hot": "^1.0.1",
     "node-elm-compiler": "^5.0.3",
+    "parcel": "^2.16.4",
     "sass": "^1.18.0"
   },
   "scripts": {

--- a/samples/3_browser/elm/src/index.html
+++ b/samples/3_browser/elm/src/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="static/bootstrap.min.css">
     <link rel="stylesheet" href="style.scss">
     <link rel="shortcut icon" href="static/favicon.ico">
-    <script defer src="main.js"></script>
+    <script defer type="module" src="main.js"></script>
     <title>EnTrance notes demo</title>
   </head>
   <body>

--- a/samples/4_router_simple/elm/package.json
+++ b/samples/4_router_simple/elm/package.json
@@ -5,15 +5,17 @@
   "license": "MIT",
   "dependencies": {
     "entrance-ws": "^1.1.1",
-    "global": "^4.3.2",
-    "parcel-bundler": "^1.12.3"
+    "global": "^4.3.2"
   },
   "devDependencies": {
+    "@parcel/transformer-elm": "2.16.4",
+    "@parcel/transformer-sass": "2.16.4",
     "cssnano": "^4.1.10",
     "elm": "^0.19.1-1",
     "elm-analyse": "^0.16.4",
     "elm-hot": "^1.0.1",
     "node-elm-compiler": "^5.0.3",
+    "parcel": "^2.16.4",
     "parcel-plugin-asset-copier": "^1.0.0",
     "sass": "^1.18.0"
   },

--- a/samples/4_router_simple/elm/src/Config/style.scss
+++ b/samples/4_router_simple/elm/src/Config/style.scss
@@ -1,3 +1,5 @@
+@use "../TopLevel/defs";
+
 /*
  * Config styling
  */
@@ -18,10 +20,10 @@
     display: inline-block;
     color: black;
     padding-right: 1em;
-    border-bottom: 1px solid $red;
+    border-bottom: 1px solid defs.$red;
    }
    .unsupported .error {
-       border-bottom-color: $green;
+       border-bottom-color: defs.$green;
    }
 
   .err-msg {
@@ -31,18 +33,18 @@
     margin-top: 3px;
     padding: 1px .5em 0;
     background-color: white;
-    color: $red;
+    color: defs.$red;
     font-weight: 500;
     font-size: 80%;
     max-width: 31em;
-    border: 1px solid $red;
+    border: 1px solid defs.$red;
     border-radius: .3em;
   }
   .unsupported .err-msg {
-    color: $green;
-    border-color: $green;
+    color: defs.$green;
+    border-color: defs.$green;
   }
 
   /* raw output */
-  .unsupported { color: $green;  }
+  .unsupported { color: defs.$green;  }
 }

--- a/samples/4_router_simple/elm/src/Connection/style.scss
+++ b/samples/4_router_simple/elm/src/Connection/style.scss
@@ -1,3 +1,5 @@
+@use "../TopLevel/defs";
+
 /*
  * Connection modal styling
  */
@@ -36,13 +38,13 @@ label {
 /*
  * Colours
  */
-.state-grey  { color: $grey;   }
-.state-amber { color: $orange; }
-.state-green { color: $green;  }
-.state-red   { color: $red;    }
+.state-grey  { color: defs.$grey;   }
+.state-amber { color: defs.$orange; }
+.state-green { color: defs.$green;  }
+.state-red   { color: defs.$red;    }
 
 input.bad-input {
     &, &:focus {
-        background-color: $muddy-red;
+        background-color: defs.$muddy-red;
     }
 }

--- a/samples/4_router_simple/elm/src/Logs/style.scss
+++ b/samples/4_router_simple/elm/src/Logs/style.scss
@@ -1,3 +1,5 @@
+@use "../TopLevel/defs";
+
 /*
  * Log styling
  */
@@ -7,6 +9,6 @@
     font-size: smaller;
 
     .light {
-        color: $grey;
+        color: defs.$grey;
     }
 }

--- a/samples/4_router_simple/elm/src/Netconf/style.scss
+++ b/samples/4_router_simple/elm/src/Netconf/style.scss
@@ -1,3 +1,5 @@
+@use "../TopLevel/defs";
+
 /*
  * Netconf style
  */
@@ -16,16 +18,16 @@ pre code {
     display: block;
     overflow-x: auto;
     padding: 0.5em;
-    background: $white;
-    color: $purple;
+    background: defs.$white;
+    color: defs.$purple;
 }
 
 .hljs-attribute, .hljs-keyword, .hljs-built_in, .hljs-attr {
-    color: $green;
+    color: defs.$green;
 }
 
 .hljs-number, .hljs-literal, .hljs-string, .hljs-name {
-    color: $blue;
+    color: defs.$blue;
 }
 
 .hljs-comment, .hljs-meta {
@@ -38,7 +40,7 @@ pre code {
 }
 
 .hljs-title, .hljs-value, .hljs-class, .hljs-function, .hljs-string {
-    color: $red;
+    color: defs.$red;
 }
 
 .hljs-keyword, .hljs-title, .hljs-class, .hljs-section {

--- a/samples/4_router_simple/elm/src/Utils/samples.scss
+++ b/samples/4_router_simple/elm/src/Utils/samples.scss
@@ -1,3 +1,5 @@
+@use "../TopLevel/defs";
+
 /*
  * Style for samples: close buttons to right of dropdown menu items
  */
@@ -8,5 +10,5 @@
 
 .dropdown-menu.with-close button.btn.close {
     margin-right: -2em;
-    color: $light-grey;
+    color: defs.$light-grey;
 }

--- a/samples/4_router_simple/elm/src/index.html
+++ b/samples/4_router_simple/elm/src/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="static/bootstrap.min.css">
     <link rel="stylesheet" href="style.scss">
     <link rel="shortcut icon" href="static/favicon.ico">
-    <script defer src="main.js"></script>
+    <script defer type="module" src="main.js"></script>
     <script defer src="static/highlight.pack.js"></script>
     <title>EnTrance router demo</title>
   </head>

--- a/samples/4_router_simple/elm/src/style.scss
+++ b/samples/4_router_simple/elm/src/style.scss
@@ -5,16 +5,16 @@
 /*
  * Definitions
  */
-@import "TopLevel/defs.scss";
+@use "TopLevel/defs.scss";
 
 /*
  * Style declarations
  */
-@import "TopLevel/style.scss";
+@use "TopLevel/style.scss";
 
-@import "Config/style.scss";
-@import "Connection/style.scss";
-@import "Logs/style.scss";
-@import "Netconf/style.scss";
-@import "Utils/samples.scss";
-@import "Utils/toast.scss";
+@use "Config/style.scss" as style2;
+@use "Connection/style.scss" as style3;
+@use "Logs/style.scss" as style4;
+@use "Netconf/style.scss" as style5;
+@use "Utils/samples.scss";
+@use "Utils/toast.scss";


### PR DESCRIPTION
Update all examples to work with node 26 (latest LTS)

This involves:
  - Updating from `parcel-bundler` (now defunct) to `parcel`.
  - Removing deprecated `@import` statements from SASS in example 4.

N.B. The server side for sample 4 is currently broken, and I haven't fixed here.
I've manually tested the other samples.